### PR TITLE
specify minimum perl version in makefile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,5 +54,6 @@ WriteMakefile(
         })
         : ()
     ),
+    ($ExtUtils::MakeMaker::VERSION >= 6.48 ? (MIN_PERL_VERSION => 5.8.0) : ()),
     %XS_DEPENDENCIES,
 );


### PR DESCRIPTION
I have been assigned this module as part of Neil Bowers CPAN Pull request challenge.

The module is failing a CPANTS metric for specifiying minimum perl version - http://cpants.cpanauthors.org/dist/Devel-Pragma 

I think this change will make that metric pass

Regards
Lisa
